### PR TITLE
GetUserInfo vereinfachen

### DIFF
--- a/usermanagement/src/main/java/com/worktimetrace/usermanagement/PrivateUserController.java
+++ b/usermanagement/src/main/java/com/worktimetrace/usermanagement/PrivateUserController.java
@@ -1,12 +1,10 @@
 package com.worktimetrace.usermanagement;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import com.worktimetrace.usermanagement.DTO.UserInfoDTO;
@@ -18,8 +16,8 @@ public class PrivateUserController {
     @Autowired
     private UserService userService;
 
-    @GetMapping("/{username}")
-    public ResponseEntity<UserInfoDTO> getUserInfoByUsername(@PathVariable String username) {
+    @GetMapping("/info")
+    public ResponseEntity<UserInfoDTO> getUserInfo() {
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
 
         String currentUsername;
@@ -29,14 +27,10 @@ public class PrivateUserController {
             currentUsername = principal.toString();
         }
 
-        if (username.equals(currentUsername)) {
-            UserInfoDTO userInfoDTO = userService.getUserInfoByUsername(username);
-            if (userInfoDTO == null) {
-                return ResponseEntity.notFound().build();
-            }
-            return ResponseEntity.ok(userInfoDTO);
-        } else {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        UserInfoDTO userInfoDTO = userService.getUserInfoByUsername(currentUsername);
+        if (userInfoDTO == null) {
+            return ResponseEntity.notFound().build();
         }
+        return ResponseEntity.ok(userInfoDTO);
     }
 }


### PR DESCRIPTION
Username als Pathvariable entfernt.
Username wird aus JWT entnommen.
Vorher auch schon, jetzt aber kein Abgleich mehr mit Pathvariable, da man sowieso nur die eigenen Infos auslesen darf.